### PR TITLE
Improve dashboard design

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -2,9 +2,25 @@ import React from 'react';
 
 
 function Dashboard() {
+  const cards = [
+    { title: 'Productos', value: 128 },
+    { title: 'Usuarios', value: 512 },
+    { title: 'Ventas', value: '$12k' },
+    { title: 'Visitas', value: '1.2k' },
+  ];
   return (
-    <main className="flex-1 p-10">
-      <h1 className="text-2xl font-semibold">Bienvenido al Panel Administrativo</h1>
+    <main className="flex-1 p-10 overflow-y-auto">
+      <h1 className="text-3xl font-bold text-gray-800 mb-8">
+        Bienvenido al Panel Administrativo
+      </h1>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {cards.map((card) => (
+          <div key={card.title} className="bg-white rounded-xl shadow p-6 text-center">
+            <p className="text-sm text-gray-500">{card.title}</p>
+            <p className="text-2xl font-semibold text-gray-700 mt-2">{card.value}</p>
+          </div>
+        ))}
+      </div>
     </main>
   );
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,10 +10,11 @@ function Sidebar() {
     'Configuración',
   ];
   return (
-    <aside className="bg-blue-600 text-white w-48 p-5">
-      <ul className="space-y-4">
+    <aside className="bg-gradient-to-b from-blue-600 to-blue-800 text-white w-60 p-6 rounded-r-3xl shadow-lg">
+      <ul className="space-y-3">
         {entries.map((entry) => (
-          <li key={entry} className="cursor-pointer hover:underline">
+          <li key={entry} className="cursor-pointer text-sm md:text-base px-3 py-2 rounded-md hover:bg-blue-700 transition-colors flex items-center">
+            <span className="mr-2">➔</span>
             {entry}
           </li>
         ))}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,5 @@
 @tailwind utilities;
 
 body {
-  @apply m-0 bg-gray-100 font-sans;
-
+  @apply m-0 bg-gradient-to-br from-gray-100 via-gray-200 to-gray-300 min-h-screen font-sans;
 }


### PR DESCRIPTION
## Summary
- enhance page background with gradient
- modernize the sidebar with gradient, rounded corners and hover styles
- show dashboard statistics in responsive cards

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685388560e9c83208deca6925dd7f756