### PR TITLE
Enable runtime configuration for Drive uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ REACT_APP_GOOGLE_API_KEY=<api_key>
 REACT_APP_GOOGLE_CLIENT_SECRET=<client_secret>
 MONGODB_URI=<mongodb_uri>
 GOOGLE_SERVICE_ACCOUNT_PATH=<path_to_service_account_json>
-# Optional folder where product images will be uploaded
+# Optional default folder where product images will be uploaded
+# If not provided, the folder can be configured at runtime from the UI
 GOOGLE_DRIVE_FOLDER_ID=<drive_folder_id>
 ```
+
+When a folder is chosen in the interface, its ID is sent to the backend using
+the `/config/drive-folder` endpoint so the server knows where to upload product
+images. This allows the destination to be changed without updating `.env`.
 
 If you modify `.env` while the development server is running, restart the React
 server so the new values are loaded.
@@ -46,8 +51,10 @@ The backend API lives in the `server/` folder. To run it locally you need Node.j
 dependencies installed and a MongoDB instance running. Set the `MONGODB_URI`
 environment variable if you want to use a custom database URL. Drive uploads
 require `GOOGLE_SERVICE_ACCOUNT_PATH` pointing to your service account JSON file
-and you may optionally define `GOOGLE_DRIVE_FOLDER_ID` to select a destination
-folder.
+and you may optionally define `GOOGLE_DRIVE_FOLDER_ID` to select a default
+destination folder. If this variable is omitted, the folder can be selected
+through the application and sent to the backend using the new configuration
+endpoint.
 
 ```bash
 cd server

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const { google } = require('googleapis');
 require('dotenv').config();
 
 const serviceAccountPath = process.env.GOOGLE_SERVICE_ACCOUNT_PATH;
-const driveFolderId = process.env.GOOGLE_DRIVE_FOLDER_ID;
+let driveFolderId = process.env.GOOGLE_DRIVE_FOLDER_ID || null;
 let drive;
 
 if (serviceAccountPath && fs.existsSync(serviceAccountPath)) {
@@ -28,6 +28,15 @@ mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true })
 
 
 const Product = require('./DB/productos');
+
+app.post('/config/drive-folder', (req, res) => {
+  const { folderId } = req.body;
+  if (!folderId || typeof folderId !== 'string') {
+    return res.status(400).json({ error: 'Folder ID required' });
+  }
+  driveFolderId = folderId;
+  res.json({ message: 'Drive folder configured' });
+});
 
 async function uploadImage(dataUrl) {
   if (!drive) throw new Error('Google Drive not configured');

--- a/src/components/GoogleDriveAuth.js
+++ b/src/components/GoogleDriveAuth.js
@@ -105,12 +105,24 @@ function GoogleDriveAuth({ onAuthenticated }) {
     }
   };
 
-  const handleFolderPathSubmit = (e) => {
+  const handleFolderPathSubmit = async (e) => {
     e.preventDefault();
     if (folderPath.trim()) {
       const trimmed = folderPath.trim();
       setFolderPath(trimmed);
       localStorage.setItem('drive_folder_path', trimmed);
+      const idMatch = trimmed.match(/[-\w]{25,}/);
+      if (idMatch) {
+        try {
+          await fetch('http://localhost:4000/config/drive-folder', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ folderId: idMatch[0] }),
+          });
+        } catch (err) {
+          console.error('Failed to store folder ID', err);
+        }
+      }
       alert(`Carpeta configurada: ${trimmed}`);
       setShowFolderOptions(false);
     }


### PR DESCRIPTION
## Summary
- store Google Drive folder ID dynamically on the server
- send Drive folder ID from frontend when folder is selected
- mention dynamic Drive folder configuration in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564ed4c17c8320a4cacb9aa09b2375