### PR TITLE
Set default server port

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -112,7 +112,7 @@ app.delete('/products/:id', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- default to port 4000 in server/index.js

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in server *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6856510e3394832082fd12f437f958fe