### PR TITLE
Use env API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ Copy `.env.example` to `.env` and set your credentials to enable Drive integrati
 ```
 REACT_APP_GOOGLE_CLIENT_ID=<client_id>
 REACT_APP_GOOGLE_API_KEY=<api_key>
+REACT_APP_API_URL=<backend_url>
 MONGODB_URI=<mongodb_uri>
 GOOGLE_SERVICE_ACCOUNT_PATH=<path_to_service_account_json>
 # Optional default folder where product images will be uploaded
 # If not provided, the folder can be configured at runtime from the UI
 GOOGLE_DRIVE_FOLDER_ID=<drive_folder_id>
 ```
+
+Set `REACT_APP_API_URL` to the base URL where the backend is running (for
+example `http://localhost:4000`).
 
 When a folder is chosen in the interface, its ID is sent to the backend using
 the `/config/drive-folder` endpoint so the server knows where to upload product

--- a/src/components/GoogleDriveAuth.js
+++ b/src/components/GoogleDriveAuth.js
@@ -5,6 +5,7 @@ const gapi = window.gapi;
 
 const CLIENT_ID = process.env.REACT_APP_GOOGLE_CLIENT_ID;
 const API_KEY = process.env.REACT_APP_GOOGLE_API_KEY;
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
 function GoogleDriveAuth({ onAuthenticated }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -112,7 +113,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
       const idMatch = trimmed.match(/[-\w]{25,}/);
       if (idMatch) {
         try {
-          await fetch('http://localhost:4000/config/drive-folder', {
+          await fetch(`${API_URL}/config/drive-folder`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ folderId: idMatch[0] }),


### PR DESCRIPTION
## Summary
- use `REACT_APP_API_URL` for Drive folder backend endpoint
- document `REACT_APP_API_URL` in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685656101ca0832094348660e209fc95