### PR TITLE
Add persistent Drive folder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ GOOGLE_DRIVE_FOLDER_ID=<drive_folder_id>
 
 When a folder is chosen in the interface, its ID is sent to the backend using
 the `/config/drive-folder` endpoint so the server knows where to upload product
-images. This allows the destination to be changed without updating `.env`.
+images. The chosen ID is stored in MongoDB so it persists across server restarts.
+You can query the current value using the `GET /config/drive-folder` endpoint.
+This allows the destination to be changed without updating `.env`.
 
 If you modify `.env` while the development server is running, restart the React
 server so the new values are loaded.

--- a/server/DB/config.js
+++ b/server/DB/config.js
@@ -1,0 +1,7 @@
+const mongoose = require('mongoose');
+
+const configSchema = new mongoose.Schema({
+  driveFolderId: String
+});
+
+module.exports = mongoose.model('Config', configSchema);


### PR DESCRIPTION
## Summary
- add Config model for server settings
- store and load Drive folder ID from MongoDB
- expose GET /config/drive-folder endpoint
- document persistence in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `cd server && npm test --silent` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_68566589bcb08320bba80fbf80898ec9