### PR TITLE
Fix product creation error handling

### DIFF
--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -165,12 +165,20 @@ function Products() {
         price: parseFloat(formData.price)
       })
     })
-      .then(res => res.json())
-      .then((product) => {
+      .then(async res => {
+        if (!res.ok) {
+          const error = await res.json().catch(() => ({}));
+          throw new Error(error.message || 'Error creating product');
+        }
+        return res.json();
+      })
+      .then(product => {
         setProducts(prev => [...prev, product]);
         closeModal();
       })
-      .catch(err => console.error(err));
+      .catch(err => {
+        console.error('Failed to create product:', err);
+      });
   };
 
   const deleteProduct = (productId) => {


### PR DESCRIPTION
## Summary
- avoid calling `res.json()` on failed responses in `handleSubmit`
- log fetch errors instead of crashing UI

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856eca1e57083209afbcaefa16304ba