### PR TITLE
Fix product list fetch error handling

### DIFF
--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -108,7 +108,13 @@ function Products() {
 
   useEffect(() => {
     fetch('http://localhost:4000/products')
-      .then(res => res.json())
+      .then(async res => {
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error || err.message || 'Failed to load products');
+        }
+        return res.json();
+      })
       .then(data => setProducts(data))
       .catch(err => console.error(err));
   }, []);


### PR DESCRIPTION
## Summary
- prevent uncaught exceptions when loading products

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f17234e08320814ddb88910657ca