### PR TITLE
Share drive folder on configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ images. The chosen ID is stored in MongoDB so it persists across server restarts
 You can query the current value using the `GET /config/drive-folder` endpoint.
 This allows the destination to be changed without updating `.env`.
 
+After configuring a new folder the backend automatically shares it with the
+service account defined by `GOOGLE_SERVICE_ACCOUNT_PATH`. A message similar to:
+
+```
+✅ Carpeta <id> compartida con <service_email> como Editor
+```
+
+will appear in the server logs confirming the folder is ready to use.
+
 If you modify `.env` while the development server is running, restart the React
 server so the new values are loaded.
 

--- a/server/index.js
+++ b/server/index.js
@@ -82,6 +82,26 @@ app.post('/config/drive-folder', async (req, res) => {
     );
     driveFolderId = cfg.driveFolderId;
     console.log(`🗂️  Drive folder actualizado. Nuevo Folder ID: ${driveFolderId}`);
+
+    // Compartir la carpeta con la cuenta de servicio inmediatamente
+    if (drive && serviceAccountPath && fs.existsSync(serviceAccountPath)) {
+      try {
+        const creds = JSON.parse(fs.readFileSync(serviceAccountPath, 'utf8'));
+        const serviceEmail = creds.client_email;
+        await drive.permissions.create({
+          fileId: driveFolderId,
+          requestBody: {
+            role: 'writer',
+            type: 'user',
+            emailAddress: serviceEmail
+          }
+        });
+        console.log(`✅ Carpeta ${driveFolderId} compartida con ${serviceEmail} como Editor`);
+      } catch (err) {
+        console.warn('⚠️ No se pudo compartir la carpeta con la cuenta de servicio:', err.message);
+      }
+    }
+
     res.json({ message: 'Drive folder configured', folderId: driveFolderId });
   } catch (err) {
     console.error('Error saving Drive folder config:', err);


### PR DESCRIPTION
## Summary
- automatically share the configured Google Drive folder with the service account
- document how to verify the sharing step

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571ac67b3c8320ac8c3455dc33ca2f