### PR TITLE
Add subfolders support to config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ destination folder. If this variable is omitted, the folder can be selected
 through the application and sent to the backend using the new configuration
 endpoint.
 
+### Subfolders
+
+The configuration model now supports an optional `subfolders` array where each
+entry has the shape `{ name, folderId, link }`. Existing deployments will
+continue to work without changes because the field is optional. To start using
+subfolders simply update your `Config` document in MongoDB by adding the array
+of objects. For example:
+
+```bash
+db.configs.updateOne({}, { $set: { subfolders: [] } })
+```
+
+You can then insert objects into the array as needed.
+
 ```bash
 cd server
 npm install           # install server dependencies

--- a/server/DB/config.js
+++ b/server/DB/config.js
@@ -1,7 +1,15 @@
 const mongoose = require('mongoose');
 
 const configSchema = new mongoose.Schema({
-  driveFolderId: String
+  driveFolderId: String,
+  subfolders: {
+    type: [{
+      name: String,
+      folderId: String,
+      link: String
+    }],
+    default: []
+  }
 });
 
 module.exports = mongoose.model('Config', configSchema);


### PR DESCRIPTION
## Summary
- support an optional `subfolders` array in the configuration model
- document how to migrate and use the new field

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571b77ca1c83208bc35e57c72f56af