### PR TITLE
Support product-specific subfolders

### DIFF
--- a/server/DB/productos.js
+++ b/server/DB/productos.js
@@ -8,7 +8,8 @@ const productSchema = new mongoose.Schema({
   keywords: [String],
   price: Number,
   currency: String,
-  image: String
+  image: String,
+  subfolderId: String
 });
 
 // El tercer parámetro fuerza el nombre de colección si lo necesitas:

--- a/server/index.js
+++ b/server/index.js
@@ -179,7 +179,7 @@ app.get('/config/subfolders', async (req, res) => {
 });
 
 // Función corregida para subir base64 a Drive usando Readable stream
-async function uploadImage(dataUrl) {
+async function uploadImage(dataUrl, parentId = driveFolderId) {
   if (!drive) throw new Error('Google Drive not configured');
 
   const match = dataUrl.match(/^data:(.+);base64,(.+)$/);
@@ -197,7 +197,7 @@ async function uploadImage(dataUrl) {
   const fileMetadata = {
     name: `product-${Date.now()}`,
     mimeType,
-    ...(driveFolderId ? { parents: [driveFolderId] } : {})
+    ...(parentId ? { parents: [parentId] } : {})
   };
 
   const response = await drive.files.create({
@@ -235,7 +235,8 @@ app.post('/products', async (req, res) => {
       req.body.image.startsWith('data:')
     ) {
       try {
-        req.body.image = await uploadImage(req.body.image);
+        const parentId = req.body.subfolderId || driveFolderId;
+        req.body.image = await uploadImage(req.body.image, parentId);
       } catch (err) {
         console.error('Error en uploadImage:', err);
         return res.status(400).json({ error: err.message });


### PR DESCRIPTION
## Summary
- enable `uploadImage` to accept a parent folder id
- store chosen subfolder id in the Product model
- allow POST /products to specify a subfolder to store images

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571d36a7388320b3027b668391c450