### PR TITLE
Update README drive permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ service account defined by `GOOGLE_SERVICE_ACCOUNT_PATH`. A message similar to:
 
 will appear in the server logs confirming the folder is ready to use.
 
+Make sure the Google account that creates the Drive folder grants **edit**
+permission to the service account either manually or from the front‑end when
+selecting the folder. If the service account is not shared on the folder,
+backend requests to create subfolders or upload images will fail with `File not
+found` errors.
+
 If you modify `.env` while the development server is running, restart the React
 server so the new values are loaded.
 


### PR DESCRIPTION
## Summary
- clarify that the Drive folder creator must share edit access with the service account

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685721d24ae08320adb10fa08a1acaf8