### PR TITLE
Improve Drive folder setup error handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -99,6 +99,10 @@ app.post('/config/drive-folder', async (req, res) => {
         console.log(`✅ Carpeta ${driveFolderId} compartida con ${serviceEmail} como Editor`);
       } catch (err) {
         console.warn('⚠️ No se pudo compartir la carpeta con la cuenta de servicio:', err.message);
+        return res.status(500).json({
+          error: 'Failed to share folder with service account',
+          details: err.message
+        });
       }
     }
 

--- a/src/components/GoogleDriveAuth.js
+++ b/src/components/GoogleDriveAuth.js
@@ -155,13 +155,20 @@ function GoogleDriveAuth({ onAuthenticated }) {
       localStorage.setItem('drive_folder_path', path);
       localStorage.setItem('drive_folder_id', folderId);
       try {
-        await fetch('http://localhost:4000/config/drive-folder', {
+        const res = await fetch('http://localhost:4000/config/drive-folder', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ folderId }),
         });
+        if (!res.ok) {
+          const payload = await res.json().catch(() => ({}));
+          throw new Error(
+            payload.error || payload.message || 'Failed to store folder ID'
+          );
+        }
       } catch (err) {
         console.error('Failed to store folder ID', err);
+        alert('Error al configurar la carpeta en el servidor');
       }
       await shareWithServiceAccount(folderId);
       alert(`Carpeta creada exitosamente: ${response.result.name}`);
@@ -220,13 +227,20 @@ function GoogleDriveAuth({ onAuthenticated }) {
         setRootFolderId(idMatch[0]);
         localStorage.setItem('drive_folder_id', idMatch[0]);
         try {
-          await fetch('http://localhost:4000/config/drive-folder', {
+          const res = await fetch('http://localhost:4000/config/drive-folder', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ folderId: idMatch[0] }),
           });
+          if (!res.ok) {
+            const payload = await res.json().catch(() => ({}));
+            throw new Error(
+              payload.error || payload.message || 'Failed to store folder ID'
+            );
+          }
         } catch (err) {
           console.error('Failed to store folder ID', err);
+          alert('Error al configurar la carpeta en el servidor');
         }
         await shareWithServiceAccount(idMatch[0]);
       }


### PR DESCRIPTION
## Summary
- return HTTP 500 if Drive folder sharing fails
- bubble the error to the UI so users see a message

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685722772f908320a3f9a0988a5d9273