### PR TITLE
Implement streaming product images from Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,15 @@ npm run dev           # start with nodemon
 
 The server listens on port `4000` by default.
 
+### Serving product images
+
+Images uploaded to Google Drive can be retrieved through the new endpoint:
+
+```http
+GET /products/:id/image
+```
+
+It streams the file from Drive using the stored `fileId` (or extracting the ID
+from the `image` field if `fileId` is missing). The response includes the proper
+`Content-Type` header so it can be used directly as the `src` of an `<img>` tag.
+

--- a/server/DB/productos.js
+++ b/server/DB/productos.js
@@ -9,6 +9,7 @@ const productSchema = new mongoose.Schema({
   price: Number,
   currency: String,
   image: String,
+  fileId: String,
   subfolderId: String
 });
 


### PR DESCRIPTION
## Summary
- store Google Drive file id in `Product` schema
- upload service returns both url and file id
- add `GET /products/:id/image` endpoint to stream images
- document new endpoint in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685729ff62748320b6ea640b1dc6176a