### PR TITLE
Add dashboard stats endpoint and dynamic dashboard

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -160,6 +160,23 @@ app.get('/database/stats', async (req, res) => {
   }
 });
 
+// Obtener conteos para el tablero principal
+app.get('/dashboard/stats', async (req, res) => {
+  try {
+    const [productCount, packageCount, diseaseCount, testimonialCount] =
+      await Promise.all([
+        Product.countDocuments(),
+        Package.countDocuments(),
+        Disease.countDocuments(),
+        Testimonial.countDocuments()
+      ]);
+    res.json({ productCount, packageCount, diseaseCount, testimonialCount });
+  } catch (err) {
+    console.error('Error fetching dashboard stats:', err);
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+});
+
 // Obtener datos de una colección específica
 app.get('/database/collections/:name/data', async (req, res) => {
   try {

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,39 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
 function Dashboard() {
+  const [stats, setStats] = useState({
+    productCount: 0,
+    packageCount: 0,
+    diseaseCount: 0,
+    testimonialCount: 0
+  });
+
+  useEffect(() => {
+    fetch(`${API_URL}/dashboard/stats`)
+      .then((res) => res.json())
+      .then((data) => setStats(data))
+      .catch((err) => console.error('Error fetching dashboard stats:', err));
+  }, []);
+
   const cards = [
-    { 
-      title: 'Productos', 
-      value: 128, 
-      change: '+12%',
+    {
+      title: 'Productos',
+      value: stats.productCount,
+      change: '',
       positive: true,
       icon: '📦',
       color: 'from-blue-500 to-cyan-500'
     },
-    { 
-      title: 'Paquetes', 
-      value: 45, 
-      change: '+18%',
+    {
+      title: 'Paquetes',
+      value: stats.packageCount,
+      change: '',
       positive: true,
       icon: '🎁',
       color: 'from-green-500 to-emerald-500'
     },
-    { 
-      title: 'Ventas', 
-      value: '$12,450', 
-      change: '+23%',
+    {
+      title: 'Índice de Enfermedades',
+      value: stats.diseaseCount,
+      change: '',
       positive: true,
-      icon: '💰',
+      icon: '🦠',
       color: 'from-purple-500 to-pink-500'
     },
-    { 
-      title: 'Testimonios', 
-      value: 89, 
-      change: '+15%',
+    {
+      title: 'Testimonios',
+      value: stats.testimonialCount,
+      change: '',
       positive: true,
       icon: '💬',
       color: 'from-orange-500 to-amber-500'
-    },
+    }
   ];
 
   const recentActivity = [


### PR DESCRIPTION
## Summary
- add `/dashboard/stats` endpoint to provide collection counts
- fetch dashboard stats in the Dashboard component and render dynamic cards
- include new "Índice de Enfermedades" card and remove "Ventas"

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685805bc6e848320926fd7e3a8e3ee43