### PR TITLE
Enable quick action modals

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import Sidebar from './components/Sidebar';
 import Dashboard from './components/Dashboard';
 import Products from './components/Products';
@@ -10,19 +10,43 @@ import Settings from './components/Settings';
 
 function App() {
   const [currentView, setCurrentView] = useState('Dashboard');
+  const productsRef = useRef();
+  const packagesRef = useRef();
+  const testimonialsRef = useRef();
+
+  const openAddProduct = () => {
+    setCurrentView('Productos');
+    setTimeout(() => productsRef.current?.openAddModal(), 0);
+  };
+
+  const openAddPackage = () => {
+    setCurrentView('Paquetes');
+    setTimeout(() => packagesRef.current?.openAddModal(), 0);
+  };
+
+  const openAddTestimonial = () => {
+    setCurrentView('Testimonios');
+    setTimeout(() => testimonialsRef.current?.openAddModal(), 0);
+  };
 
   const renderCurrentView = () => {
     switch (currentView) {
       case 'Dashboard':
-        return <Dashboard />;
+        return (
+          <Dashboard
+            onAddProduct={openAddProduct}
+            onAddPackage={openAddPackage}
+            onAddTestimonial={openAddTestimonial}
+          />
+        );
       case 'Productos':
-        return <Products />;
+        return <Products ref={productsRef} />;
       case 'Paquetes':
-        return <Packages />;
+        return <Packages ref={packagesRef} />;
       case 'Índice de Enfermedades':
         return <Diseases />;
       case 'Testimonios':
-        return <Testimonials />;
+        return <Testimonials ref={testimonialsRef} />;
       case 'BD':
         return <Database />;
       case 'Configuración':

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
-function Dashboard() {
+function Dashboard({ onAddProduct, onAddPackage, onAddTestimonial }) {
   const [stats, setStats] = useState({
     productCount: 0,
     packageCount: 0,
@@ -125,11 +125,15 @@ function Dashboard() {
           <h2 className="text-xl font-semibold text-slate-800 mb-6">Acciones Rápidas</h2>
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
-              { name: 'Agregar Producto', icon: '➕', color: 'from-blue-500 to-cyan-500' },
-              { name: 'Crear Paquete', icon: '🎁', color: 'from-green-500 to-emerald-500' },
-              { name: 'Configurar', icon: '⚙️', color: 'from-purple-500 to-pink-500' },
+              { name: 'Agregar Producto', icon: '➕', color: 'from-blue-500 to-cyan-500', onClick: onAddProduct },
+              { name: 'Crear Paquete', icon: '🎁', color: 'from-green-500 to-emerald-500', onClick: onAddPackage },
+              { name: 'Subir Testimonio', icon: '💬', color: 'from-purple-500 to-pink-500', onClick: onAddTestimonial },
             ].map((action) => (
-              <button key={action.name} className="p-4 rounded-xl border border-slate-200/50 hover:border-slate-300/50 transition-all duration-200 hover:shadow-md group bg-white/50 hover:bg-white/70">
+              <button
+                key={action.name}
+                onClick={action.onClick}
+                className="p-4 rounded-xl border border-slate-200/50 hover:border-slate-300/50 transition-all duration-200 hover:shadow-md group bg-white/50 hover:bg-white/70"
+              >
                 <div className={`w-10 h-10 rounded-lg bg-gradient-to-r ${action.color} flex items-center justify-center text-white mb-3 mx-auto group-hover:scale-110 transition-transform`}>
                   {action.icon}
                 </div>

--- a/src/components/Packages.js
+++ b/src/components/Packages.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
-function Packages({ products }) {
+const Packages = forwardRef(({ products }, ref) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [packages, setPackages] = useState([]);
   const [editingPackage, setEditingPackage] = useState(null);
@@ -133,6 +133,16 @@ function Packages({ products }) {
     });
   };
 
+  const openAddModal = () => {
+    setEditingPackage(null);
+    setFormData({ name: '', description: '', selectedProducts: [] });
+    setIsModalOpen(true);
+  };
+
+  useImperativeHandle(ref, () => ({
+    openAddModal
+  }));
+
   return (
     <main className="flex-1 p-8 bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 overflow-y-auto min-h-screen">
       <div className="max-w-7xl mx-auto">
@@ -147,11 +157,7 @@ function Packages({ products }) {
             </p>
           </div>
           <button
-            onClick={() => {
-              setEditingPackage(null);
-              setFormData({ name: '', description: '', selectedProducts: [] });
-              setIsModalOpen(true);
-            }}
+            onClick={openAddModal}
             className="bg-gradient-to-r from-green-500 to-emerald-500 text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-1 flex items-center space-x-2"
           >
             <span className="text-lg">➕</span>
@@ -359,6 +365,6 @@ function Packages({ products }) {
       </div>
     </main>
   );
-}
+});
 
 export default Packages;

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
-function Products() {
+const Products = forwardRef((props, ref) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingProduct, setEditingProduct] = useState(null);
   const [products, setProducts] = useState([]);
@@ -176,6 +176,23 @@ function Products() {
     }));
   };
 
+  const openAddModal = () => {
+    setEditingProduct(null);
+    setFormData({
+      name: '',
+      category: '',
+      suggestedInfo: '',
+      keywords: [],
+      price: '',
+      currency: 'USD',
+      image: '',
+      imageFile: null,
+      subfolderId: ''
+    });
+    setCurrentKeyword('');
+    setIsModalOpen(true);
+  };
+
   const openEditModal = (product) => {
     setEditingProduct(product);
     setFormData({
@@ -199,6 +216,10 @@ function Products() {
   const closeInfoModal = () => {
     setInfoProduct(null);
   };
+
+  useImperativeHandle(ref, () => ({
+    openAddModal
+  }));
 
 const handleSubmit = (e) => {
   e.preventDefault();
@@ -312,7 +333,7 @@ const handleSubmit = (e) => {
             </p>
           </div>
           <button
-            onClick={() => setIsModalOpen(true)}
+            onClick={openAddModal}
             className="bg-gradient-to-r from-blue-500 to-cyan-500 text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-1 flex items-center space-x-2"
           >
             <span className="text-lg">➕</span>
@@ -863,6 +884,6 @@ const handleSubmit = (e) => {
       </div>
     </main>
   );
-}
+});
 
 export default Products;

--- a/src/components/Testimonials.js
+++ b/src/components/Testimonials.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
-function Testimonials() {
+const Testimonials = forwardRef((props, ref) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTestimonial, setEditingTestimonial] = useState(null);
   const [testimonials, setTestimonials] = useState([]);
@@ -157,6 +157,22 @@ function Testimonials() {
     });
   };
 
+  const openAddModal = () => {
+    setEditingTestimonial(null);
+    setFormData({
+      name: '',
+      associatedProducts: [],
+      videoUrl: '',
+      videoFile: null,
+      subfolderId: ''
+    });
+    setIsModalOpen(true);
+  };
+
+  useImperativeHandle(ref, () => ({
+    openAddModal
+  }));
+
   return (
     <main className="flex-1 p-8 bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 overflow-y-auto min-h-screen">
       <div className="max-w-7xl mx-auto">
@@ -171,10 +187,7 @@ function Testimonials() {
             </p>
           </div>
           <button
-            onClick={() => {
-              setEditingTestimonial(null);
-              setIsModalOpen(true);
-            }}
+            onClick={openAddModal}
             className="bg-gradient-to-r from-purple-500 to-pink-500 text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transition-all duration-200 hover:-translate-y-1 flex items-center space-x-2"
           >
             <span className="text-lg">➕</span>
@@ -389,6 +402,6 @@ function Testimonials() {
       </div>
     </main>
   );
-}
+});
 
 export default Testimonials;


### PR DESCRIPTION
## Summary
- add refs and callbacks in `App.js` to open each "add" modal
- expose `openAddModal` from Products, Packages and Testimonials using `forwardRef`
- wire Dashboard quick action buttons to these callbacks

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685808dec300832099dcc83742d6ab8b