### PR TITLE
Implement full activity management

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -210,6 +210,17 @@ app.get('/activities', async (req, res) => {
   }
 });
 
+app.delete('/activities/:id', async (req, res) => {
+  try {
+    const act = await Activity.findByIdAndDelete(req.params.id);
+    if (!act) return res.status(404).json({ error: 'Activity not found' });
+    res.json({ message: 'Activity deleted' });
+  } catch (err) {
+    console.error('Error deleting activity:', err);
+    res.status(500).json({ error: 'Failed to delete activity' });
+  }
+});
+
 // Obtener datos de una colección específica
 app.get('/database/collections/:name/data', async (req, res) => {
   try {

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Diseases from './components/Diseases';
 import Testimonials from './components/Testimonials';
 import Database from './components/Database';
 import Settings from './components/Settings';
+import Activities from './components/Activities';
 
 function App() {
   const [currentView, setCurrentView] = useState('Dashboard');
@@ -37,6 +38,7 @@ function App() {
             onAddProduct={openAddProduct}
             onAddPackage={openAddPackage}
             onAddTestimonial={openAddTestimonial}
+            onViewActivities={() => setCurrentView('Actividades')}
           />
         );
       case 'Productos':
@@ -47,6 +49,8 @@ function App() {
         return <Diseases />;
       case 'Testimonios':
         return <Testimonials ref={testimonialsRef} />;
+      case 'Actividades':
+        return <Activities />;
       case 'BD':
         return <Database />;
       case 'Configuración':

--- a/src/components/Activities.js
+++ b/src/components/Activities.js
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
+
+function Activities() {
+  const [activities, setActivities] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${API_URL}/activities`)
+      .then(res => res.json())
+      .then(data => setActivities(data))
+      .catch(err => console.error('Error fetching activities:', err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const deleteActivity = (id) => {
+    if (window.confirm('¿Estás seguro de que quieres eliminar esta actividad?')) {
+      fetch(`${API_URL}/activities/${id}`, { method: 'DELETE' })
+        .then(() => setActivities(prev => prev.filter(a => a._id !== id)))
+        .catch(err => console.error('Error deleting activity:', err));
+    }
+  };
+
+  if (loading) {
+    return (
+      <main className="flex-1 p-8 bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 overflow-y-auto min-h-screen">
+        <div className="max-w-7xl mx-auto">
+          <div className="flex items-center justify-center h-64">
+            <div className="text-center">
+              <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+              <p className="text-slate-600">Cargando actividades...</p>
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex-1 p-8 bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 overflow-y-auto min-h-screen">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold bg-gradient-to-r from-slate-800 to-slate-600 bg-clip-text text-transparent mb-2">
+            Todas las Actividades 📋
+          </h1>
+          <p className="text-slate-600 text-lg">Historial completo de acciones en el sistema</p>
+        </div>
+
+        <div className="space-y-4">
+          {activities.map(activity => (
+            <div key={activity._id} className="flex items-start space-x-3 p-3 rounded-lg bg-white/80 backdrop-blur-sm border border-white/20">
+              <div className="w-2 h-2 rounded-full mt-2 bg-blue-500"></div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-slate-800">{activity.action}</p>
+                <p className="text-xs text-slate-500">{new Date(activity.createdAt).toLocaleString()}</p>
+              </div>
+              <button
+                onClick={() => deleteActivity(activity._id)}
+                className="text-red-600 hover:text-red-700 text-sm font-medium"
+              >
+                Eliminar
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default Activities;

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
-function Dashboard({ onAddProduct, onAddPackage, onAddTestimonial }) {
+function Dashboard({ onAddProduct, onAddPackage, onAddTestimonial, onViewActivities }) {
   const [stats, setStats] = useState({
     productCount: 0,
     packageCount: 0,
@@ -55,7 +55,7 @@ function Dashboard({ onAddProduct, onAddPackage, onAddTestimonial }) {
   const [activities, setActivities] = useState([]);
 
   useEffect(() => {
-    fetch(`${API_URL}/activities?limit=10`)
+    fetch(`${API_URL}/activities?limit=5`)
       .then(res => res.json())
       .then(setActivities)
       .catch(err => console.error('Error fetching activities:', err));
@@ -112,7 +112,10 @@ function Dashboard({ onAddProduct, onAddPackage, onAddTestimonial }) {
                 </div>
               ))}
             </div>
-            <button className="w-full mt-4 text-sm text-purple-600 hover:text-purple-700 font-medium transition-colors">
+            <button
+              onClick={onViewActivities}
+              className="w-full mt-4 text-sm text-purple-600 hover:text-purple-700 font-medium transition-colors"
+            >
               Ver toda la actividad →
             </button>
           </div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -7,6 +7,7 @@ function Sidebar({ currentView, setCurrentView }) {
     { name: 'Paquetes', icon: '🎁' },
     { name: 'Índice de Enfermedades', icon: '🏥' },
     { name: 'Testimonios', icon: '💬' },
+    { name: 'Actividades', icon: '📋' },
     { name: 'BD', icon: '🗄️' },
     { name: 'Configuración', icon: '⚙️' },
   ];


### PR DESCRIPTION
## Summary
- limit dashboard activities to latest five
- add ability to view all activities and delete them
- expose `DELETE /activities/:id` API
- hook new Activities view into sidebar and routing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586d77dd348320948d041b5460fa3e