### PR TITLE
Add GOOGLE_SERVICE_ACCOUNT_JSON docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,16 @@ Copy `.env.example` to `.env` and set your credentials to enable Drive integrati
 REACT_APP_GOOGLE_CLIENT_ID=<client_id>
 REACT_APP_GOOGLE_API_KEY=<api_key>
 REACT_APP_API_URL=http://localhost:4000
+# MongoDB connection
 MONGODB_URI=<mongodb_uri>
+
+# Service account credentials
+# Either provide a path to the JSON file
 GOOGLE_SERVICE_ACCOUNT_PATH=<path_to_service_account_json>
+# or supply the JSON directly (escape newlines in the private key)
+# Example:
+# GOOGLE_SERVICE_ACCOUNT_JSON='{"type":"service_account","project_id":"my-project","private_key_id":"abc123","private_key":"-----BEGIN PRIVATE KEY-----\\nMII...\\n-----END PRIVATE KEY-----\\n","client_email":"service@my-project.iam.gserviceaccount.com","client_id":"1234567890","token_uri":"https://oauth2.googleapis.com/token"}'
+
 # Optional default folder where product images will be uploaded
 # If not provided, the folder can be configured at runtime from the UI
 GOOGLE_DRIVE_FOLDER_ID=<drive_folder_id>
@@ -50,7 +58,8 @@ You can query the current value using the `GET /config/drive-folder` endpoint.
 This allows the destination to be changed without updating `.env`.
 
 After configuring a new folder the backend automatically shares it with the
-service account defined by `GOOGLE_SERVICE_ACCOUNT_PATH`. A message similar to:
+service account defined by `GOOGLE_SERVICE_ACCOUNT_PATH` or
+`GOOGLE_SERVICE_ACCOUNT_JSON`. A message similar to:
 
 ```
 ✅ Carpeta <id> compartida con <service_email> como Editor
@@ -72,8 +81,9 @@ server so the new values are loaded.
 The backend API lives in the `server/` folder. To run it locally you need Node.js
 dependencies installed and a MongoDB instance running. Set the `MONGODB_URI`
 environment variable if you want to use a custom database URL. Drive uploads
-require `GOOGLE_SERVICE_ACCOUNT_PATH` pointing to your service account JSON file
-and you may optionally define `GOOGLE_DRIVE_FOLDER_ID` and
+require a service account configured via `GOOGLE_SERVICE_ACCOUNT_PATH` or
+`GOOGLE_SERVICE_ACCOUNT_JSON`. You may optionally define
+`GOOGLE_DRIVE_FOLDER_ID` and
 `GOOGLE_DRIVE_TESTIMONIALS_FOLDER_ID` to select default upload folders for
 product images and testimonial videos. If these variables are omitted, the
 folders can be selected through the application and sent to the backend using


### PR DESCRIPTION
## Summary
- document providing service account credentials with `GOOGLE_SERVICE_ACCOUNT_JSON`
- clarify both env vars where referenced

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c0bd3268832086b890b7b7ecbaa8