### PR TITLE
Add optional OAuth upload mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,5 @@ GOOGLE_DRIVE_FOLDER_ID=
 # Folder must belong to a Shared Drive or configure OAuth delegation
 GOOGLE_DRIVE_TESTIMONIALS_FOLDER_ID=
 GOOGLE_SHARED_DRIVE_ID=
+USE_OAUTH_UPLOAD=
 PORT=4000

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ GOOGLE_DRIVE_FOLDER_ID=<drive_folder_id>
 GOOGLE_DRIVE_TESTIMONIALS_FOLDER_ID=<drive_folder_id>
 # ID of the Shared Drive used by server/shared-drive-example.js
 GOOGLE_SHARED_DRIVE_ID=<drive_id>
+# Enable user OAuth uploads instead of the service account
+USE_OAUTH_UPLOAD=false
 ```
 
 > **Important**: Service accounts do not have their own storage quota. The
@@ -154,6 +156,28 @@ Environment variable `GOOGLE_DRIVE_TESTIMONIALS_FOLDER_ID` can define the
 default upload folder. The folder ID may also be configured at runtime via the
 `POST /config/testimonials-folder` endpoint and queried with
 `GET /config/testimonials-folder`.
+
+### OAuth uploads
+
+Set `USE_OAUTH_UPLOAD=true` if you prefer to upload files using a user's OAuth
+token instead of the service account. The `GoogleDriveAuth` component stores the
+access token in `localStorage` under `drive_token`. Include this token when
+calling the backend:
+
+```js
+const token = localStorage.getItem('drive_token');
+fetch('/api/products', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify(data)
+});
+```
+
+When this header is present the server performs Drive actions on behalf of the
+authenticated user.
 
 ### Shared Drive example
 


### PR DESCRIPTION
## Summary
- add `USE_OAUTH_UPLOAD` flag and OAuth drive client support
- adjust upload/delete helpers to accept request object
- document OAuth token flow in README
- update `.env.example`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b81cc79188320be27eb4513b9bb00