### PR TITLE
Add user auth with approval workflow

### DIFF
--- a/server/DB/users.js
+++ b/server/DB/users.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, unique: true },
+  id4life: String,
+  name: String,
+  passwordHash: String,
+  country: String,
+  line: String,
+  approved: { type: Boolean, default: false },
+  driveFolderId: String
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "axios": "^1.6.7",
     "cors": "^2.8.5",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.1",
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
     "googleapis": "^132.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -8,12 +8,21 @@ import Testimonials from './components/Testimonials';
 import Database from './components/Database';
 import Settings from './components/Settings';
 import Activities from './components/Activities';
+import Login from './components/Login';
+import Register from './components/Register';
+import AdminUsers from './components/AdminUsers';
 
 function App() {
   const [currentView, setCurrentView] = useState('Dashboard');
   const productsRef = useRef();
   const packagesRef = useRef();
   const testimonialsRef = useRef();
+  const [auth, setAuth] = useState({
+    token: localStorage.getItem('token'),
+    approved: localStorage.getItem('approved') === '1',
+    isAdmin: localStorage.getItem('isAdmin') === '1'
+  });
+  const [showRegister, setShowRegister] = useState(false);
 
   const openAddProduct = () => {
     setCurrentView('Productos');
@@ -55,14 +64,28 @@ function App() {
         return <Database />;
       case 'Configuración':
         return <Settings />;
+      case 'Usuarios':
+        return <AdminUsers />;
       default:
         return <Dashboard />;
     }
   };
 
+  if (!auth.token) {
+    return showRegister ? (
+      <Register onRegistered={() => setShowRegister(false)} onShowLogin={() => setShowRegister(false)} />
+    ) : (
+      <Login onLogin={data => setAuth({ token: data.token, approved: data.approved, isAdmin: data.isAdmin })} onShowRegister={() => setShowRegister(true)} />
+    );
+  }
+
+  if (!auth.approved) {
+    return <div className="p-8">Cuenta pendiente de aprobación.</div>;
+  }
+
   return (
     <div className="flex h-screen">
-      <Sidebar currentView={currentView} setCurrentView={setCurrentView} />
+      <Sidebar currentView={currentView} setCurrentView={setCurrentView} isAdmin={auth.isAdmin} />
       {renderCurrentView()}
     </div>
   );

--- a/src/components/AdminUsers.js
+++ b/src/components/AdminUsers.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
+
+function AdminUsers() {
+  const [users, setUsers] = useState([]);
+
+  const load = () => {
+    fetch(`${API_URL}/auth/pending`)
+      .then(res => res.json())
+      .then(setUsers)
+      .catch(console.error);
+  };
+
+  useEffect(load, []);
+
+  const approve = id => {
+    fetch(`${API_URL}/auth/approve/${id}`, { method: 'PATCH' })
+      .then(res => res.json())
+      .then(() => load())
+      .catch(console.error);
+  };
+
+  return (
+    <main className="flex-1 p-8 bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 overflow-y-auto min-h-screen">
+      <div className="max-w-3xl mx-auto space-y-4">
+        <h1 className="text-3xl font-bold">Usuarios Pendientes</h1>
+        {users.map(u => (
+          <div key={u._id} className="p-4 bg-white rounded shadow flex justify-between">
+            <div>
+              <p className="font-medium">{u.name} ({u.email})</p>
+              <p className="text-sm text-gray-500">{u.country}</p>
+            </div>
+            <button className="bg-green-500 text-white px-3 py-1 rounded" onClick={() => approve(u._id)}>Aprobar</button>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+export default AdminUsers;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
+
+function Login({ onLogin, onShowRegister }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setError(null);
+    fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+      .then(async res => {
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || 'Login failed');
+        }
+        return res.json();
+      })
+      .then(data => {
+        localStorage.setItem('token', data.token);
+        localStorage.setItem('approved', data.approved ? '1' : '0');
+        localStorage.setItem('isAdmin', data.isAdmin ? '1' : '0');
+        if (onLogin) onLogin(data);
+      })
+      .catch(err => setError(err.message));
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-50">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80 space-y-4">
+        <h2 className="text-xl font-bold text-center">Iniciar Sesión</h2>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          className="w-full border p-2 rounded"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Contraseña"
+          className="w-full border p-2 rounded"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-blue-500 text-white py-2 rounded" type="submit">
+          Entrar
+        </button>
+        <button
+          type="button"
+          onClick={onShowRegister}
+          className="w-full text-sm text-blue-500 underline"
+        >
+          Registrarse
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
+
+function Register({ onRegistered, onShowLogin }) {
+  const [form, setForm] = useState({ email: '', id4life: '', name: '', password: '', country: '', line: '' });
+  const [error, setError] = useState(null);
+
+  const handleChange = e => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    setError(null);
+    fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+      .then(async res => {
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || 'Registration failed');
+        }
+        return res.json();
+      })
+      .then(() => {
+        if (onRegistered) onRegistered();
+      })
+      .catch(err => setError(err.message));
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-50">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-96 space-y-3">
+        <h2 className="text-xl font-bold text-center">Registro</h2>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <input className="w-full border p-2 rounded" name="email" placeholder="Email" value={form.email} onChange={handleChange} />
+        <input className="w-full border p-2 rounded" name="id4life" placeholder="ID 4Life" value={form.id4life} onChange={handleChange} />
+        <input className="w-full border p-2 rounded" name="name" placeholder="Nombre" value={form.name} onChange={handleChange} />
+        <input className="w-full border p-2 rounded" name="country" placeholder="País" value={form.country} onChange={handleChange} />
+        <input className="w-full border p-2 rounded" name="line" placeholder="Línea" value={form.line} onChange={handleChange} />
+        <input type="password" className="w-full border p-2 rounded" name="password" placeholder="Contraseña" value={form.password} onChange={handleChange} />
+        <button className="w-full bg-blue-500 text-white py-2 rounded" type="submit">Crear Cuenta</button>
+        <button type="button" onClick={onShowLogin} className="w-full text-sm text-blue-500 underline">Volver</button>
+      </form>
+    </div>
+  );
+}
+
+export default Register;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function Sidebar({ currentView, setCurrentView }) {
+function Sidebar({ currentView, setCurrentView, isAdmin }) {
   const entries = [
     { name: 'Dashboard', icon: '📊' },
     { name: 'Productos', icon: '📦' },
@@ -11,6 +11,7 @@ function Sidebar({ currentView, setCurrentView }) {
     { name: 'BD', icon: '🗄️' },
     { name: 'Configuración', icon: '⚙️' },
   ];
+  if (isAdmin) entries.push({ name: 'Usuarios', icon: '👥' });
 
   const admin = { name: 'Admin', email: 'admin@medipanel.com' };
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './index.css';      // ← aquí importas Tailwind
 import App from './App';
 
+// Inyecta token de autenticación en todas las peticiones fetch
+const originalFetch = window.fetch;
+window.fetch = (url, options = {}) => {
+  const token = localStorage.getItem('token');
+  const headers = { ...(options.headers || {}) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return originalFetch(url, { ...options, headers });
+};
+
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- add `User` mongoose model
- secure server with JWT authentication and user approval
- create Drive folder when approving a user
- integrate auth token in React app
- add login/register/admin user components
- show admin menu in Sidebar

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68646e2a839c83209c7a8fe6f04936ea