### PR TITLE
Restrict admin-only sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,9 +72,9 @@ function App() {
       case 'Actividades':
         return <Activities />;
       case 'BD':
-        return <Database />;
+        return auth.isAdmin ? <Database /> : <Dashboard />;
       case 'Configuración':
-        return <Settings />;
+        return auth.isAdmin ? <Settings /> : <Dashboard />;
       case 'Usuarios':
         return <AdminUsers />;
       default:

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,10 +8,15 @@ function Sidebar({ currentView, setCurrentView, isAdmin, email, onLogout }) {
     { name: 'Índice de Enfermedades', icon: '🏥' },
     { name: 'Testimonios', icon: '💬' },
     { name: 'Actividades', icon: '📋' },
-    { name: 'BD', icon: '🗄️' },
-    { name: 'Configuración', icon: '⚙️' },
   ];
-  if (isAdmin) entries.push({ name: 'Usuarios', icon: '👥' });
+
+  if (isAdmin) {
+    entries.push(
+      { name: 'BD', icon: '🗄️' },
+      { name: 'Configuración', icon: '⚙️' },
+      { name: 'Usuarios', icon: '👥' }
+    );
+  }
 
   const userInfo = { role: isAdmin ? 'Admin' : 'Invitado', email };
 


### PR DESCRIPTION
## Summary
- update sidebar to only show DB and Settings links when admin
- prevent non-admins from accessing DB or Settings even if view changes

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648f978e50832088c23156f5ffc526