### PR TITLE
Track activity actors

### DIFF
--- a/server/DB/activities.js
+++ b/server/DB/activities.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const activitySchema = new mongoose.Schema({
   action: String,
   details: String,
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
   createdAt: {
     type: Date,
     default: Date.now

--- a/src/components/Activities.js
+++ b/src/components/Activities.js
@@ -53,7 +53,10 @@ function Activities() {
               <div className="w-2 h-2 rounded-full mt-2 bg-blue-500"></div>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-slate-800">{activity.action}</p>
-                <p className="text-xs text-slate-500">{new Date(activity.createdAt).toLocaleString()}</p>
+                <p className="text-xs text-slate-500">
+                  {new Date(activity.createdAt).toLocaleString()} -{' '}
+                  {activity.user?.name || activity.user?.email || 'Desconocido'}
+                </p>
               </div>
               <button
                 onClick={() => deleteActivity(activity._id)}


### PR DESCRIPTION
## Summary
- extend activity schema with `user` reference
- log the acting user in server routes
- populate `user` when listing activities
- show the actor in the activity list UI

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686490be39f48320bb3b7e6751449c66