### PR TITLE
Persist Google Drive token in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ npm run dev           # start with nodemon
 
 The server listens on port `4000` by default.
 
+### Drive access tokens
+
+The `/config/drive-token` endpoint persists the Google Drive OAuth token in
+MongoDB. `GET /config/drive-token` returns `{ token, exp }` while
+`POST /config/drive-token` updates these values. The React client automatically
+loads any stored token on startup and saves new tokens whenever a user
+authenticates. Signing out sends an empty token so the server record is cleared.
+This lets the Drive connection survive browser restarts without requiring the
+user to log in again.
+
 ### Serving product images
 
 Images uploaded to Google Drive can be retrieved through the new endpoint:

--- a/server/DB/config.js
+++ b/server/DB/config.js
@@ -3,6 +3,8 @@ const mongoose = require('mongoose');
 const configSchema = new mongoose.Schema({
   driveFolderId: String,
   testimonialsFolderId: String,
+  driveAccessToken: String,
+  driveTokenExp: Number,
   subfolders: {
     type: [{
       name: String,


### PR DESCRIPTION
## Summary
- extend `Config` model with Google Drive token fields
- load `driveAccessToken` and `driveTokenExp` on server startup
- expose `/config/drive-token` endpoints to read/update the token
- sync token state from the React app
- document automatic token persistence

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850e78cf5c832099a228679ae789a9