### PR TITLE
Improve conversation loading handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1496,7 +1496,9 @@ app.get('/conversations/:id', async (req, res) => {
   try {
     const conv = await Conversation.findById(req.params.id);
     if (!conv) return res.status(404).json({ error: 'Conversation not found' });
-    res.json(conv);
+    const data = conv.toObject();
+    if (!Array.isArray(data.messages)) data.messages = [];
+    res.json(data);
   } catch (err) {
     console.error('Error fetching conversation:', err);
     res.status(500).json({ error: 'Failed to fetch conversation' });


### PR DESCRIPTION
## Summary
- guard `/conversations/:id` route to always return a `messages` array
- handle fetch errors when opening a conversation
- show an error or empty state in the conversation modal

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885270a6f288320b0f82f074862eda5