### PR TITLE
Improve auth handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,28 @@ import Register from './components/Register';
 import PendingApproval from './components/PendingApproval';
 import AdminUsers from './components/AdminUsers';
 
+// Verifica expiración del token JWT para cerrar sesión automáticamente
+function checkTokenExpiration() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const { exp } = JSON.parse(atob(token.split('.')[1]));
+    if (exp && Date.now() >= exp * 1000) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('approved');
+      localStorage.removeItem('isAdmin');
+      localStorage.removeItem('email');
+    }
+  } catch (e) {
+    localStorage.removeItem('token');
+    localStorage.removeItem('approved');
+    localStorage.removeItem('isAdmin');
+    localStorage.removeItem('email');
+  }
+}
+
+checkTokenExpiration();
+
 function App() {
   const [currentView, setCurrentView] = useState('Dashboard');
   const productsRef = useRef();

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,22 @@ import App from './App';
 
 // Inyecta token de autenticación en todas las peticiones fetch
 const originalFetch = window.fetch;
-window.fetch = (url, options = {}) => {
+window.fetch = async (url, options = {}) => {
   const token = localStorage.getItem('token');
   const headers = { ...(options.headers || {}) };
   if (token) headers.Authorization = `Bearer ${token}`;
-  return originalFetch(url, { ...options, headers });
+
+  const response = await originalFetch(url, { ...options, headers });
+
+  if (response.status === 401 || response.status === 403) {
+    localStorage.removeItem('token');
+    localStorage.removeItem('approved');
+    localStorage.removeItem('isAdmin');
+    localStorage.removeItem('email');
+    window.location.reload();
+  }
+
+  return response;
 };
 
 


### PR DESCRIPTION
## Summary
- reset local storage and reload on 401/403
- validate token expiration on startup

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852fea92b08320849b3b20295beb77