### PR TITLE
Improve auth error handling

### DIFF
--- a/src/components/Activities.js
+++ b/src/components/Activities.js
@@ -8,7 +8,13 @@ function Activities() {
 
   useEffect(() => {
     fetch(`${API_URL}/activities`)
-      .then(res => res.json())
+      .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
+        return res.json();
+      })
       .then(data => setActivities(data))
       .catch(err => console.error('Error fetching activities:', err))
       .finally(() => setLoading(false));
@@ -17,7 +23,13 @@ function Activities() {
   const deleteActivity = (id) => {
     if (window.confirm('¿Estás seguro de que quieres eliminar esta actividad?')) {
       fetch(`${API_URL}/activities/${id}`, { method: 'DELETE' })
-        .then(() => setActivities(prev => prev.filter(a => a._id !== id)))
+        .then(res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return;
+          }
+          setActivities(prev => prev.filter(a => a._id !== id));
+        })
         .catch(err => console.error('Error deleting activity:', err));
     }
   };

--- a/src/components/Conversations.js
+++ b/src/components/Conversations.js
@@ -10,7 +10,13 @@ function Conversations() {
 
   useEffect(() => {
     fetch(`${API_URL}/conversations`)
-      .then(res => res.json())
+      .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
+        return res.json();
+      })
       .then(data => setConversations(Array.isArray(data) ? data : []))
       .catch(err => console.error('Error fetching conversations:', err))
       .finally(() => setLoading(false));
@@ -20,6 +26,10 @@ function Conversations() {
     setError(null);
     fetch(`${API_URL}/conversations/${id}`)
       .then(res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          throw new Error('Forbidden');
+        }
         if (!res.ok) throw new Error('Failed to fetch conversation');
         return res.json();
       })
@@ -39,7 +49,13 @@ function Conversations() {
   const deleteConversation = id => {
     if (window.confirm('¿Estás seguro de que quieres eliminar esta conversación?')) {
       fetch(`${API_URL}/conversations/${id}`, { method: 'DELETE' })
-        .then(() => setConversations(prev => prev.filter(c => c._id !== id)))
+        .then(res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return;
+          }
+          setConversations(prev => prev.filter(c => c._id !== id));
+        })
         .catch(err => console.error('Error deleting conversation:', err));
     }
   };

--- a/src/components/GoogleDriveAuth.js
+++ b/src/components/GoogleDriveAuth.js
@@ -189,6 +189,10 @@ function GoogleDriveAuth({ onAuthenticated }) {
       },
     })
       .then(async (res) => {
+        if (res.status === 403) {
+          alert("No autorizado");
+          return [];
+        }
         if (!res.ok) throw new Error("Unauthorized");
         return res.json();
       })
@@ -252,6 +256,10 @@ function GoogleDriveAuth({ onAuthenticated }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ folderId }),
       });
+      if (res.status === 403) {
+        alert("No autorizado");
+        return;
+      }
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
         throw new Error(
@@ -282,6 +290,10 @@ function GoogleDriveAuth({ onAuthenticated }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: subfolderName.trim() }),
       });
+      if (res.status === 403) {
+        alert("No autorizado");
+        return;
+      }
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
         throw new Error(
@@ -307,6 +319,10 @@ function GoogleDriveAuth({ onAuthenticated }) {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
       });
+      if (res.status === 403) {
+        alert("No autorizado");
+        return;
+      }
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
         throw new Error(
@@ -339,6 +355,10 @@ function GoogleDriveAuth({ onAuthenticated }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ folderId: idMatch[0] }),
         });
+        if (res.status === 403) {
+          alert("No autorizado");
+          return;
+        }
         if (!res.ok) {
           const payload = await res.json().catch(() => ({}));
           throw new Error(

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -122,6 +122,10 @@ const Products = forwardRef((props, ref) => {
   useEffect(() => {
     fetch(`${API_URL}/products`)
       .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));
           throw new Error(err.error || err.message || 'Failed to load products');
@@ -132,7 +136,13 @@ const Products = forwardRef((props, ref) => {
       .catch(err => console.error(err));
 
     fetch(`${API_URL}/config/subfolders`)
-      .then(res => res.json())
+      .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
+        return res.json();
+      })
       .then(setSubfolders)
       .catch(err => console.error('Failed to load subfolders', err));
   }, []);
@@ -237,6 +247,10 @@ const handleSubmit = (e) => {
     })
   })
     .then(async res => {
+      if (res.status === 403) {
+        alert('No autorizado');
+        throw new Error('Forbidden');
+      }
       if (!res.ok) {
         // Lee el JSON del error y construye un mensaje claro
         const payload = await res.json().catch(() => ({}));
@@ -275,12 +289,16 @@ const handleUpdate = (e) => {
       payload.image = formData.image;
     }
 
-    fetch(`${API_URL}/products/${editingProduct._id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    })
+  fetch(`${API_URL}/products/${editingProduct._id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
       .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          throw new Error('Forbidden');
+        }
         if (!res.ok) {
           const payload = await res.json().catch(() => ({}));
           const msg = payload.error || payload.details || payload.message || 'Error al actualizar producto';
@@ -304,7 +322,11 @@ const handleUpdate = (e) => {
   const deleteProduct = (productId) => {
     if (window.confirm('¿Estás seguro de que quieres eliminar este producto?')) {
       fetch(`${API_URL}/products/${productId}`, { method: 'DELETE' })
-        .then(() => {
+        .then(res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return;
+          }
           setProducts(prev => prev.filter(product => product._id !== productId));
         })
         .catch(err => console.error(err));

--- a/src/components/Testimonials.js
+++ b/src/components/Testimonials.js
@@ -32,6 +32,10 @@ const Testimonials = forwardRef((props, ref) => {
       }
     })
       .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
         if (!res.ok) throw new Error('Unauthorized');
         return res.json();
       })
@@ -46,6 +50,10 @@ const Testimonials = forwardRef((props, ref) => {
       }
     })
       .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
         if (!res.ok) throw new Error('Unauthorized');
         return res.json();
       })
@@ -60,6 +68,10 @@ const Testimonials = forwardRef((props, ref) => {
       }
     })
       .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return [];
+        }
         if (!res.ok) throw new Error('Unauthorized');
         return res.json();
       })
@@ -139,6 +151,10 @@ const Testimonials = forwardRef((props, ref) => {
       body: JSON.stringify(payload)
     })
       .then(async res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          throw new Error('Forbidden');
+        }
         if (!res.ok) throw new Error('Unauthorized');
         return res.json();
       })
@@ -165,6 +181,10 @@ const Testimonials = forwardRef((props, ref) => {
       headers: { 'Authorization': `Bearer ${token}` }
     })
       .then(res => {
+        if (res.status === 403) {
+          alert('No autorizado');
+          return;
+        }
         if (!res.ok) throw new Error('Unauthorized');
         setTestimonials(prev => prev.filter(t => t._id !== testimonialId));
       })

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ window.fetch = async (url, options = {}) => {
 
   const response = await originalFetch(url, { ...options, headers });
 
-  if (response.status === 401 || response.status === 403) {
+  if (response.status === 401) {
     localStorage.removeItem('token');
     localStorage.removeItem('approved');
     localStorage.removeItem('isAdmin');


### PR DESCRIPTION
## Summary
- update fetch override to reload only on 401
- surface 403 errors in components with a friendly alert
- handle forbidden responses in Activities, Conversations, GoogleDriveAuth, Products and Testimonials

## Testing
- `npm test` *(fails: react-scripts not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68853b29b6e88320a22e8e541348bea3