### PR TITLE
Add apiFetch helper with Authorization token

### DIFF
--- a/src/components/Activities.js
+++ b/src/components/Activities.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -7,11 +8,11 @@ function Activities() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`${API_URL}/activities`)
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
+      apiFetch(`${API_URL}/activities`)
+        .then(async res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return [];
         }
         return res.json();
       })
@@ -22,11 +23,11 @@ function Activities() {
 
   const deleteActivity = (id) => {
     if (window.confirm('¿Estás seguro de que quieres eliminar esta actividad?')) {
-      fetch(`${API_URL}/activities/${id}`, { method: 'DELETE' })
-        .then(res => {
-          if (res.status === 403) {
-            alert('No autorizado');
-            return;
+        apiFetch(`${API_URL}/activities/${id}`, { method: 'DELETE' })
+          .then(res => {
+            if (res.status === 403) {
+              alert('No autorizado');
+              return;
           }
           setActivities(prev => prev.filter(a => a._id !== id));
         })

--- a/src/components/Conversations.js
+++ b/src/components/Conversations.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -9,11 +10,11 @@ function Conversations() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch(`${API_URL}/conversations`)
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
+      apiFetch(`${API_URL}/conversations`)
+        .then(async res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return [];
         }
         return res.json();
       })
@@ -24,11 +25,11 @@ function Conversations() {
 
   const openConversation = id => {
     setError(null);
-    fetch(`${API_URL}/conversations/${id}`)
-      .then(res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          throw new Error('Forbidden');
+      apiFetch(`${API_URL}/conversations/${id}`)
+        .then(res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            throw new Error('Forbidden');
         }
         if (!res.ok) throw new Error('Failed to fetch conversation');
         return res.json();
@@ -48,11 +49,11 @@ function Conversations() {
 
   const deleteConversation = id => {
     if (window.confirm('¿Estás seguro de que quieres eliminar esta conversación?')) {
-      fetch(`${API_URL}/conversations/${id}`, { method: 'DELETE' })
-        .then(res => {
-          if (res.status === 403) {
-            alert('No autorizado');
-            return;
+        apiFetch(`${API_URL}/conversations/${id}`, { method: 'DELETE' })
+          .then(res => {
+            if (res.status === 403) {
+              alert('No autorizado');
+              return;
           }
           setConversations(prev => prev.filter(c => c._id !== id));
         })

--- a/src/components/Diseases.js
+++ b/src/components/Diseases.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -18,17 +19,17 @@ function Diseases() {
     dosages: {}
   });
 
-  useEffect(() => {
-    fetch(`${API_URL}/diseases`)
-      .then(res => res.json())
-      .then(setDiseases)
-      .catch(err => console.error('Failed to load diseases', err));
+    useEffect(() => {
+      apiFetch(`${API_URL}/diseases`)
+        .then(res => res.json())
+        .then(setDiseases)
+        .catch(err => console.error('Failed to load diseases', err));
 
-    fetch(`${API_URL}/packages`)
-      .then(res => res.json())
-      .then(data => {
-        setAllPackages(data);
-        setDisplayPackages(data);
+      apiFetch(`${API_URL}/packages`)
+        .then(res => res.json())
+        .then(data => {
+          setAllPackages(data);
+          setDisplayPackages(data);
       })
       .catch(err => console.error('Failed to load packages', err));
   }, []);
@@ -36,11 +37,11 @@ function Diseases() {
   useEffect(() => {
     if (!formData.name) return;
 
-    fetch(`${API_URL}/diseases/describe`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: formData.name })
-    })
+      apiFetch(`${API_URL}/diseases/describe`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: formData.name })
+      })
       .then(res => res.json())
       .then(data => {
         if (data.description)
@@ -48,11 +49,11 @@ function Diseases() {
       })
       .catch(err => console.error('Failed to describe disease', err));
 
-    fetch(`${API_URL}/diseases/recommend-package`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: formData.name })
-    })
+      apiFetch(`${API_URL}/diseases/recommend-package`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: formData.name })
+      })
       .then(res => res.json())
       .then(pkgs => {
         if (Array.isArray(pkgs)) {
@@ -112,11 +113,11 @@ function Diseases() {
     };
 
     if (editingDisease) {
-      fetch(`${API_URL}/diseases/${editingDisease._id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
+        apiFetch(`${API_URL}/diseases/${editingDisease._id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        })
         .then(res => res.json())
         .then(updated => {
           setDiseases(prev => prev.map(d => (d._id === updated._id ? updated : d)));
@@ -129,11 +130,11 @@ function Diseases() {
           setIsSaving(false);
         });
     } else {
-      fetch(`${API_URL}/diseases`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
+        apiFetch(`${API_URL}/diseases`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        })
         .then(res => res.json())
         .then(created => {
           setDiseases(prev => [...prev, created]);
@@ -150,9 +151,9 @@ function Diseases() {
 
   const deleteDisease = (id) => {
     if (!window.confirm('¿Estás seguro de que quieres eliminar esta enfermedad?')) return;
-    fetch(`${API_URL}/diseases/${id}`, { method: 'DELETE' })
-      .then(() => setDiseases(prev => prev.filter(d => d._id !== id)))
-      .catch(err => console.error('Failed to delete disease', err));
+      apiFetch(`${API_URL}/diseases/${id}`, { method: 'DELETE' })
+        .then(() => setDiseases(prev => prev.filter(d => d._id !== id)))
+        .catch(err => console.error('Failed to delete disease', err));
   };
 
   const closeModal = () => {

--- a/src/components/Packages.js
+++ b/src/components/Packages.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -17,11 +18,11 @@ const Packages = forwardRef(({ products }, ref) => {
   const [availableProducts, setAvailableProducts] = useState([]);
   const [suggestMessage, setSuggestMessage] = useState('');
 
-  useEffect(() => {
-    fetch(`${API_URL}/packages`)
-      .then(res => res.json())
-      .then(setPackages)
-      .catch(err => console.error('Failed to load packages', err));
+    useEffect(() => {
+      apiFetch(`${API_URL}/packages`)
+        .then(res => res.json())
+        .then(setPackages)
+        .catch(err => console.error('Failed to load packages', err));
   }, []);
 
   useEffect(() => {
@@ -30,11 +31,11 @@ const Packages = forwardRef(({ products }, ref) => {
       setSuggestMessage('');
       return;
     }
-    fetch(`${API_URL}/packages/suggested`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: formData.name })
-    })
+      apiFetch(`${API_URL}/packages/suggested`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: formData.name })
+      })
       .then(res => res.json())
       .then(data => {
         setAvailableProducts(Array.isArray(data) ? data : []);
@@ -89,11 +90,11 @@ const Packages = forwardRef(({ products }, ref) => {
       productIds: formData.selectedProducts.map(p => p._id || p.id)
     };
     if (editingPackage) {
-      fetch(`${API_URL}/packages/${editingPackage._id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
+        apiFetch(`${API_URL}/packages/${editingPackage._id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        })
         .then(res => res.json())
         .then(updated => {
           setPackages(prev => prev.map(p => (p._id === updated._id ? updated : p)));
@@ -106,11 +107,11 @@ const Packages = forwardRef(({ products }, ref) => {
           setIsSaving(false);
         });
     } else {
-      fetch(`${API_URL}/packages`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      })
+        apiFetch(`${API_URL}/packages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        })
         .then(res => res.json())
         .then(pkg => {
           setPackages(prev => [...prev, pkg]);
@@ -127,10 +128,10 @@ const Packages = forwardRef(({ products }, ref) => {
 
   const deletePackage = (packageId) => {
     if (window.confirm('¿Estás seguro de que quieres eliminar este paquete?')) {
-      fetch(`${API_URL}/packages/${packageId}`, { method: 'DELETE' })
-        .then(() => {
-          setPackages(prev => prev.filter(pkg => pkg._id !== packageId));
-        })
+        apiFetch(`${API_URL}/packages/${packageId}`, { method: 'DELETE' })
+          .then(() => {
+            setPackages(prev => prev.filter(pkg => pkg._id !== packageId));
+          })
         .catch(err => console.error('Failed to delete package', err));
     }
   };

--- a/src/components/Products.js
+++ b/src/components/Products.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -119,13 +120,13 @@ const Products = forwardRef((props, ref) => {
   const currencies = ['USD', 'EUR', 'MXN', 'COP', 'ARS'];
   const subfolderMap = Object.fromEntries(subfolders.map(sf => [sf.folderId, sf.name]));
 
-  useEffect(() => {
-    fetch(`${API_URL}/products`)
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
-        }
+    useEffect(() => {
+      apiFetch(`${API_URL}/products`)
+        .then(async res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return [];
+          }
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));
           throw new Error(err.error || err.message || 'Failed to load products');
@@ -135,12 +136,12 @@ const Products = forwardRef((props, ref) => {
       .then(data => setProducts(data))
       .catch(err => console.error(err));
 
-    fetch(`${API_URL}/config/subfolders`)
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
-        }
+      apiFetch(`${API_URL}/config/subfolders`)
+        .then(async res => {
+          if (res.status === 403) {
+            alert('No autorizado');
+            return [];
+          }
         return res.json();
       })
       .then(setSubfolders)
@@ -237,11 +238,11 @@ const handleSubmit = (e) => {
   setSubmitError(null); // Limpia cualquier error previo
   setIsSaving(true);
 
-  fetch(`${API_URL}/products`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      ...formData,                         // Incluye todos los campos del formulario
+    apiFetch(`${API_URL}/products`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...formData,                         // Incluye todos los campos del formulario
       price: parseFloat(formData.price),  // Convierte price a número
       subfolderId: formData.subfolderId || undefined
     })
@@ -289,11 +290,11 @@ const handleUpdate = (e) => {
       payload.image = formData.image;
     }
 
-  fetch(`${API_URL}/products/${editingProduct._id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
-  })
+    apiFetch(`${API_URL}/products/${editingProduct._id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
       .then(async res => {
         if (res.status === 403) {
           alert('No autorizado');
@@ -321,11 +322,11 @@ const handleUpdate = (e) => {
 
   const deleteProduct = (productId) => {
     if (window.confirm('¿Estás seguro de que quieres eliminar este producto?')) {
-      fetch(`${API_URL}/products/${productId}`, { method: 'DELETE' })
-        .then(res => {
-          if (res.status === 403) {
-            alert('No autorizado');
-            return;
+        apiFetch(`${API_URL}/products/${productId}`, { method: 'DELETE' })
+          .then(res => {
+            if (res.status === 403) {
+              alert('No autorizado');
+              return;
           }
           setProducts(prev => prev.filter(product => product._id !== productId));
         })

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,5 @@
+export function apiFetch(url, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = { ...(options.headers || {}), Authorization: `Bearer ${token}` };
+  return fetch(url, { ...options, headers });
+}


### PR DESCRIPTION
## Summary
- centralize auth header logic in new `apiFetch` util
- switch Products, Packages, Diseases, Conversations and Activities to use `apiFetch`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853efeeb248320a75f5ca4f890de13