### PR TITLE
Centralize auth error handling

### DIFF
--- a/src/components/Activities.js
+++ b/src/components/Activities.js
@@ -8,14 +8,8 @@ function Activities() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-      apiFetch(`${API_URL}/activities`)
-        .then(async res => {
-          if (res.status === 403) {
-            alert('No autorizado');
-            return [];
-        }
-        return res.json();
-      })
+    apiFetch(`${API_URL}/activities`)
+      .then(res => res.json())
       .then(data => setActivities(data))
       .catch(err => console.error('Error fetching activities:', err))
       .finally(() => setLoading(false));
@@ -23,12 +17,8 @@ function Activities() {
 
   const deleteActivity = (id) => {
     if (window.confirm('¿Estás seguro de que quieres eliminar esta actividad?')) {
-        apiFetch(`${API_URL}/activities/${id}`, { method: 'DELETE' })
-          .then(res => {
-            if (res.status === 403) {
-              alert('No autorizado');
-              return;
-          }
+      apiFetch(`${API_URL}/activities/${id}`, { method: 'DELETE' })
+        .then(() => {
           setActivities(prev => prev.filter(a => a._id !== id));
         })
         .catch(err => console.error('Error deleting activity:', err));

--- a/src/components/Conversations.js
+++ b/src/components/Conversations.js
@@ -11,26 +11,16 @@ function Conversations() {
 
   useEffect(() => {
       apiFetch(`${API_URL}/conversations`)
-        .then(async res => {
-          if (res.status === 403) {
-            alert('No autorizado');
-            return [];
-        }
-        return res.json();
-      })
-      .then(data => setConversations(Array.isArray(data) ? data : []))
-      .catch(err => console.error('Error fetching conversations:', err))
-      .finally(() => setLoading(false));
+        .then(res => res.json())
+        .then(data => setConversations(Array.isArray(data) ? data : []))
+        .catch(err => console.error('Error fetching conversations:', err))
+        .finally(() => setLoading(false));
   }, []);
 
   const openConversation = id => {
     setError(null);
-      apiFetch(`${API_URL}/conversations/${id}`)
-        .then(res => {
-          if (res.status === 403) {
-            alert('No autorizado');
-            throw new Error('Forbidden');
-        }
+    apiFetch(`${API_URL}/conversations/${id}`)
+      .then(res => {
         if (!res.ok) throw new Error('Failed to fetch conversation');
         return res.json();
       })
@@ -49,14 +39,10 @@ function Conversations() {
 
   const deleteConversation = id => {
     if (window.confirm('¿Estás seguro de que quieres eliminar esta conversación?')) {
-        apiFetch(`${API_URL}/conversations/${id}`, { method: 'DELETE' })
-          .then(res => {
-            if (res.status === 403) {
-              alert('No autorizado');
-              return;
-          }
-          setConversations(prev => prev.filter(c => c._id !== id));
-        })
+    apiFetch(`${API_URL}/conversations/${id}`, { method: 'DELETE' })
+      .then(() => {
+        setConversations(prev => prev.filter(c => c._id !== id));
+      })
         .catch(err => console.error('Error deleting conversation:', err));
     }
   };

--- a/src/components/GoogleDriveAuth.js
+++ b/src/components/GoogleDriveAuth.js
@@ -189,10 +189,6 @@ function GoogleDriveAuth({ onAuthenticated }) {
       },
     })
       .then(async (res) => {
-        if (res.status === 403) {
-          alert("No autorizado");
-          return [];
-        }
         if (!res.ok) throw new Error("Unauthorized");
         return res.json();
       })
@@ -256,10 +252,6 @@ function GoogleDriveAuth({ onAuthenticated }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ folderId }),
       });
-      if (res.status === 403) {
-        alert("No autorizado");
-        return;
-      }
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
         throw new Error(
@@ -290,10 +282,6 @@ function GoogleDriveAuth({ onAuthenticated }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: subfolderName.trim() }),
       });
-      if (res.status === 403) {
-        alert("No autorizado");
-        return;
-      }
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
         throw new Error(
@@ -319,10 +307,6 @@ function GoogleDriveAuth({ onAuthenticated }) {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
       });
-      if (res.status === 403) {
-        alert("No autorizado");
-        return;
-      }
       if (!res.ok) {
         const payload = await res.json().catch(() => ({}));
         throw new Error(
@@ -355,10 +339,6 @@ function GoogleDriveAuth({ onAuthenticated }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ folderId: idMatch[0] }),
         });
-        if (res.status === 403) {
-          alert("No autorizado");
-          return;
-        }
         if (!res.ok) {
           const payload = await res.json().catch(() => ({}));
           throw new Error(

--- a/src/components/Testimonials.js
+++ b/src/components/Testimonials.js
@@ -25,56 +25,26 @@ const Testimonials = forwardRef((props, ref) => {
     if (!token) return;
 
     // Carga de testimonios
-    fetch(`${API_URL}/testimonials`, {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      }
+    apiFetch(`${API_URL}/testimonials`, {
+      headers: { 'Content-Type': 'application/json' }
     })
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
-        }
-        if (!res.ok) throw new Error('Unauthorized');
-        return res.json();
-      })
+      .then(res => res.json())
       .then(data => setTestimonials(Array.isArray(data) ? data : []))
       .catch(err => console.error('Failed to load testimonials', err));
 
     // Carga de productos
-    fetch(`${API_URL}/products`, {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      }
+    apiFetch(`${API_URL}/products`, {
+      headers: { 'Content-Type': 'application/json' }
     })
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
-        }
-        if (!res.ok) throw new Error('Unauthorized');
-        return res.json();
-      })
+      .then(res => res.json())
       .then(data => setProducts(Array.isArray(data) ? data : []))
       .catch(err => console.error('Failed to load products', err));
 
     // Carga de subcarpetas
-    fetch(`${API_URL}/config/subfolders`, {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      }
+    apiFetch(`${API_URL}/config/subfolders`, {
+      headers: { 'Content-Type': 'application/json' }
     })
-      .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return [];
-        }
-        if (!res.ok) throw new Error('Unauthorized');
-        return res.json();
-      })
+      .then(res => res.json())
       .then(data => setSubfolders(Array.isArray(data) ? data : []))
       .catch(err => console.error('Failed to load subfolders', err));
   }, []);
@@ -140,21 +110,13 @@ const Testimonials = forwardRef((props, ref) => {
       ? `${API_URL}/testimonials/${editingTestimonial._id}`
       : `${API_URL}/testimonials`;
     const method = editingTestimonial ? 'PUT' : 'POST';
-    const token = localStorage.getItem('token');
 
-    fetch(url, {
+    apiFetch(url, {
       method,
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     })
       .then(async res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          throw new Error('Forbidden');
-        }
         if (!res.ok) throw new Error('Unauthorized');
         return res.json();
       })
@@ -176,15 +138,8 @@ const Testimonials = forwardRef((props, ref) => {
   const deleteTestimonial = (testimonialId) => {
     if (!window.confirm('¿Estás seguro de que quieres eliminar este testimonio?')) return;
     const token = localStorage.getItem('token');
-    fetch(`${API_URL}/testimonials/${testimonialId}`, {
-      method: 'DELETE',
-      headers: { 'Authorization': `Bearer ${token}` }
-    })
+    apiFetch(`${API_URL}/testimonials/${testimonialId}`, { method: 'DELETE' })
       .then(res => {
-        if (res.status === 403) {
-          alert('No autorizado');
-          return;
-        }
         if (!res.ok) throw new Error('Unauthorized');
         setTestimonials(prev => prev.filter(t => t._id !== testimonialId));
       })

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';      // ← aquí importas Tailwind
 import App from './App';
+import { handleApiError } from './utils/api';
 
 // Inyecta token de autenticación en todas las peticiones fetch
 const originalFetch = window.fetch;
@@ -12,13 +13,7 @@ window.fetch = async (url, options = {}) => {
 
   const response = await originalFetch(url, { ...options, headers });
 
-  if (response.status === 401) {
-    localStorage.removeItem('token');
-    localStorage.removeItem('approved');
-    localStorage.removeItem('isAdmin');
-    localStorage.removeItem('email');
-    window.location.reload();
-  }
+  handleApiError(response);
 
   return response;
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,5 +1,18 @@
-export function apiFetch(url, options = {}) {
+export function handleApiError(res) {
+  if (res.status === 401 || res.status === 403) {
+    localStorage.removeItem('token');
+    localStorage.removeItem('approved');
+    localStorage.removeItem('isAdmin');
+    localStorage.removeItem('email');
+    window.location.reload();
+  }
+}
+
+export async function apiFetch(url, options = {}) {
   const token = localStorage.getItem('token');
-  const headers = { ...(options.headers || {}), Authorization: `Bearer ${token}` };
-  return fetch(url, { ...options, headers });
+  const headers = { ...(options.headers || {}) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(url, { ...options, headers });
+  handleApiError(res);
+  return res;
 }


### PR DESCRIPTION
## Summary
- add centralized `handleApiError` helper for unauthorized responses
- use the new helper in fetch wrapper
- remove manual 403 checks in components
- rely on apiFetch so expired tokens redirect to login

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853ff4a00c8320bd1303361c1be36c