### PR TITLE
Show alert on auth error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ window.fetch = async (url, options = {}) => {
 
   const response = await originalFetch(url, { ...options, headers });
 
-  handleApiError(response);
+  await handleApiError(response);
 
   return response;
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,10 +1,16 @@
-export function handleApiError(res) {
+export async function handleApiError(res) {
   if (res.status === 401 || res.status === 403) {
-    localStorage.removeItem('token');
-    localStorage.removeItem('approved');
-    localStorage.removeItem('isAdmin');
-    localStorage.removeItem('email');
-    window.location.reload();
+    try {
+      const data = await res.clone().json().catch(() => ({}));
+      const message = data.error || 'Sesión inválida';
+      window.alert(message);
+    } finally {
+      localStorage.removeItem('token');
+      localStorage.removeItem('approved');
+      localStorage.removeItem('isAdmin');
+      localStorage.removeItem('email');
+      window.location.reload();
+    }
   }
 }
 
@@ -13,6 +19,6 @@ export async function apiFetch(url, options = {}) {
   const headers = { ...(options.headers || {}) };
   if (token) headers.Authorization = `Bearer ${token}`;
   const res = await fetch(url, { ...options, headers });
-  handleApiError(res);
+  await handleApiError(res);
   return res;
 }


### PR DESCRIPTION
## Summary
- show an alert with the API error message when authentication fails
- wait for user confirmation before clearing credentials and reloading the app

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68854276e83c8320bbdf9a5c836647a3