### PR TITLE
Use apiFetch for auth-protected routes

### DIFF
--- a/src/components/AdminUsers.js
+++ b/src/components/AdminUsers.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -6,7 +7,7 @@ function AdminUsers() {
   const [users, setUsers] = useState([]);
 
   const load = () => {
-    fetch(`${API_URL}/auth/users`)
+    apiFetch(`${API_URL}/auth/users`)
       .then(res => res.json())
       .then(setUsers)
       .catch(console.error);
@@ -15,14 +16,14 @@ function AdminUsers() {
   useEffect(load, []);
 
   const approve = id => {
-    fetch(`${API_URL}/auth/approve/${id}`, { method: 'PATCH' })
+    apiFetch(`${API_URL}/auth/approve/${id}`, { method: 'PATCH' })
       .then(res => res.json())
       .then(() => load())
       .catch(console.error);
   };
 
   const toggleDisable = (id, disabled) => {
-    fetch(`${API_URL}/auth/disable/${id}`, {
+    apiFetch(`${API_URL}/auth/disable/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ disabled: !disabled })

--- a/src/components/Database.js
+++ b/src/components/Database.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { apiFetch } from '../utils/api';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000';
 
@@ -24,7 +25,7 @@ function Database() {
     try {
       setLoading(true);
       const token = localStorage.getItem('token');
-      const response = await fetch(`${API_URL}/database/collections`, {
+      const response = await apiFetch(`${API_URL}/database/collections`, {
         headers: { Authorization: `Bearer ${token}` }
       });
       if (!response.ok) throw new Error('Failed to load collections');
@@ -40,7 +41,7 @@ function Database() {
   const loadDatabaseStats = async () => {
     try {
       const token = localStorage.getItem('token');
-      const response = await fetch(`${API_URL}/database/stats`, {
+      const response = await apiFetch(`${API_URL}/database/stats`, {
         headers: { Authorization: `Bearer ${token}` }
       });
       if (!response.ok) throw new Error('Failed to load stats');
@@ -54,7 +55,7 @@ function Database() {
   const loadCollectionData = async (collectionName) => {
     try {
       const token = localStorage.getItem('token');
-      const response = await fetch(
+      const response = await apiFetch(
         `${API_URL}/database/collections/${collectionName}/data`,
         { headers: { Authorization: `Bearer ${token}` } }
       );
@@ -71,7 +72,7 @@ function Database() {
     try {
       setBackupLoading(true);
       const token = localStorage.getItem('token');
-      const response = await fetch(`${API_URL}/database/backup`, {
+      const response = await apiFetch(`${API_URL}/database/backup`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -107,7 +108,7 @@ function Database() {
       const text = await file.text();
       const backup = JSON.parse(text);
       const token = localStorage.getItem('token');
-      const resp = await fetch(`${API_URL}/database/import`, {
+      const resp = await apiFetch(`${API_URL}/database/import`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -130,7 +131,7 @@ function Database() {
   const deleteCollection = async (collectionName) => {
     try {
       const token = localStorage.getItem('token');
-      const response = await fetch(`${API_URL}/database/collections/${collectionName}`, {
+      const response = await apiFetch(`${API_URL}/database/collections/${collectionName}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${token}` }
       });

--- a/src/components/GoogleDriveAuth.js
+++ b/src/components/GoogleDriveAuth.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { apiFetch } from "../utils/api";
 
 // Helper to wait until the gapi script has finished loading
 const waitForGapi = () => {
@@ -65,7 +66,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
 
         if (!savedFolderId) {
           try {
-            const res = await fetch(`${API_URL}/config/drive-folder`);
+            const res = await apiFetch(`${API_URL}/config/drive-folder`);
             const data = await res.json();
             if (data.folderId) {
               savedFolderId = data.folderId;
@@ -81,7 +82,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
         if ((!savedToken || !savedExp || Date.now() >= savedExp) && localStorage.getItem("token")) {
           try {
             const jwt = localStorage.getItem("token");
-            const resp = await fetch(`${API_URL}/config/drive-token`, {
+            const resp = await apiFetch(`${API_URL}/config/drive-token`, {
               headers: { Authorization: `Bearer ${jwt}` }
             });
             if (resp.ok) {
@@ -140,7 +141,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
           localStorage.setItem("drive_token_exp", expiration.toString());
           try {
             const jwt = localStorage.getItem("token");
-            await fetch(`${API_URL}/config/drive-token`, {
+            await apiFetch(`${API_URL}/config/drive-token`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -182,7 +183,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
   const loadSubfolders = () => {
     if (!isAuthenticated) return;
     const jwt = localStorage.getItem("token");
-    fetch(`${API_URL}/config/subfolders`, {
+    apiFetch(`${API_URL}/config/subfolders`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${jwt}`,
@@ -208,7 +209,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
 
   const shareWithServiceAccount = async (folderId) => {
     try {
-      const res = await fetch(`${API_URL}/config/service-account`);
+      const res = await apiFetch(`${API_URL}/config/service-account`);
       const data = await res.json();
       if (res.ok && data.email) {
         await window.gapi.client.drive.permissions.create({
@@ -247,7 +248,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
       const shared = await shareWithServiceAccount(folderId);
       if (!shared) return;
 
-      const res = await fetch(`${API_URL}/config/drive-folder`, {
+      const res = await apiFetch(`${API_URL}/config/drive-folder`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ folderId }),
@@ -277,7 +278,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
     if (!rootFolderId || !subfolderName.trim()) return;
     setIsCreatingSub(true);
     try {
-      const res = await fetch(`${API_URL}/config/subfolders`, {
+      const res = await apiFetch(`${API_URL}/config/subfolders`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: subfolderName.trim() }),
@@ -303,7 +304,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
   const handleDeleteSubfolder = async (id) => {
     if (!id) return;
     try {
-      const res = await fetch(`${API_URL}/config/subfolders/${id}`, {
+      const res = await apiFetch(`${API_URL}/config/subfolders/${id}`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
       });
@@ -334,7 +335,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
       const shared = await shareWithServiceAccount(idMatch[0]);
       if (!shared) return;
       try {
-        const res = await fetch(`${API_URL}/config/drive-folder`, {
+        const res = await apiFetch(`${API_URL}/config/drive-folder`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ folderId: idMatch[0] }),
@@ -363,7 +364,7 @@ function GoogleDriveAuth({ onAuthenticated }) {
     }
     if (localStorage.getItem("token")) {
       const jwt = localStorage.getItem("token");
-      fetch(`${API_URL}/config/drive-token`, {
+      apiFetch(`${API_URL}/config/drive-token`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- import and use `apiFetch` in `AdminUsers`
- switch `/config/*` requests in `GoogleDriveAuth` to use `apiFetch`
- apply `apiFetch` to database admin routes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688555cf3e20832094a3514fba6a9861