### PR TITLE
Restrict drive token routes to admin

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -617,12 +617,12 @@ app.get('/config/drive-folder', (req, res) => {
 });
 
 // Obtener token de Google Drive
-app.get('/config/drive-token', (req, res) => {
+app.get('/config/drive-token', adminOnly, (req, res) => {
   res.json({ token: driveAccessToken, exp: driveTokenExp });
 });
 
 // Guardar token de Google Drive
-app.post('/config/drive-token', async (req, res) => {
+app.post('/config/drive-token', adminOnly, async (req, res) => {
   const { token, exp } = req.body || {};
   try {
     const cfg = await Config.findOneAndUpdate(


### PR DESCRIPTION
## Summary
- only administrators can read or update the stored Google Drive OAuth token

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68855bb5b73083209be9b182430a5bd1