### PR TITLE
Ignore server env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 .env
 # Ignorar credenciales de Google
 server/credenciales/*.json
+server/.env


### PR DESCRIPTION
## Summary
- avoid accidentally committing env files from `server/` by ignoring `server/.env`

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68859f3b0c9c8320b93b2254e991f71f