### PR TITLE
Update README for server .env expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ npm install           # install server dependencies
 npm run dev           # start with nodemon
 ```
 
+When running `npm run dev` the backend expects a `.env` file inside the
+`server/` directory. Copy your root configuration there if it doesn't exist:
+
+```bash
+cp .env server/.env
+```
+
+If you prefer keeping the environment file only in the project root, modify
+`server/index.js` to load it explicitly:
+
+```javascript
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+```
+
+Either approach ensures the server loads the correct variables.
+
 The server listens on port `4000` by default.
 
 ### Drive access tokens


### PR DESCRIPTION
## Summary
- clarify that `npm run dev` expects `.env` inside `server/`
- show how to copy the root `.env` or load it from `index.js`

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*
- `npm install --silent` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6885a1a23c748320a2be003353229064