### PR TITLE
Add root Drive folder creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ selecting the folder. If the service account is not shared on the folder,
 backend requests to create subfolders or upload images will fail with `File not
 found` errors.
 
+You can also create a new Drive folder directly from the API:
+
+```http
+POST /config/create-root-folder
+```
+
+Send an optional `name` and the server will create the folder (default
+`MediPanel_Storage`), share it with the service account and store the resulting
+`folderId` in MongoDB. The response includes the `folderId` and a direct `link`.
+
 If you modify `.env` while the development server is running, restart the React
 server so the new values are loaded.
 


### PR DESCRIPTION
## Summary
- support creation of the root Drive folder
- document the new endpoint

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885abe53ee48320be20592e15831c7f