### PR TITLE
fix: remove duplicate getInfoUsers import

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,6 @@ const Activity = require('./DB/activities');
 const User = require('./DB/users');
 const Conversation = require('./DB/conversations');
 const { getInfoUsers } = require('./DB/infoUsers');
-const { getInfoUsers } = require('./DB/infoUsers');
 const { MongoClient, ObjectId } = require('mongodb');
 const infoUsersCollection = 'InfoUsers';
 


### PR DESCRIPTION
## Summary
- remove duplicate import of `getInfoUsers`

## Testing
- `npm test`
- `MONGODB_URI="mongodb://localhost:27017/test?serverSelectionTimeoutMS=2000" node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6892823b2b108320954df7f8444b86a0