### PR TITLE
Broaden phone normalization to strip any domain

### DIFF
--- a/server/utils/normalizePhone.js
+++ b/server/utils/normalizePhone.js
@@ -1,6 +1,6 @@
 function normalizePhone(phone = '') {
   return String(phone)
-    .replace(/@s\.whatsapp\.net$/, '')
+    .replace(/@[^\s]+$/, '')
     .replace(/\D/g, '');
 }
 

--- a/src/utils/normalizePhone.js
+++ b/src/utils/normalizePhone.js
@@ -1,5 +1,5 @@
 export function normalizePhone(phone = '') {
   return String(phone)
-    .replace(/@s\.whatsapp\.net$/, '')
+    .replace(/@[^\s]+$/, '')
     .replace(/\D/g, '');
 }


### PR DESCRIPTION
## Summary
- allow phone normalization to remove any `@domain` suffix and keep only digits on both client and server
- confirm conversation lookup continues to normalize numbers before comparison

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892c8180d04832087a06cfa2d88a34f